### PR TITLE
Allow all origin on IPFS client

### DIFF
--- a/packages/carrot-scripts/src/scripts/start.js
+++ b/packages/carrot-scripts/src/scripts/start.js
@@ -247,12 +247,7 @@ const main = async () => {
                 },
                 API: {
                     HTTPHeaders: {
-                        "Access-Control-Allow-Origin": [
-                            "http://127.0.0.1:9000",
-                            "http://127.0.0.1:9000/",
-                            "http://localhost:9000",
-                            "http://localhost:9000/",
-                        ],
+                        "Access-Control-Allow-Origin": ["*"],
                     },
                 },
             },


### PR DESCRIPTION
The IPFS should allow access to all origins, since we don't know on what port the playground is going to start.